### PR TITLE
Don't dismiss the picker when tapping

### DIFF
--- a/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/AbstractActionSheetPicker.m
+++ b/CoreActionSheetPicker/CoreActionSheetPicker/Pickers/AbstractActionSheetPicker.m
@@ -798,8 +798,9 @@ CG_INLINE BOOL isIPhone4() {
 #pragma mark UIGestureRecognizerDelegate
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
-    CGPoint location = [gestureRecognizer locationInView:self.toolbar];
-    return !CGRectContainsPoint(self.toolbar.bounds, location);
+    CGPoint toolbarLocation = [gestureRecognizer locationInView:self.toolbar];
+    CGPoint actionSheetLocation = [gestureRecognizer locationInView:self.actionSheet];
+    return !(CGRectContainsPoint(self.toolbar.bounds, toolbarLocation) || CGRectContainsPoint(self.actionSheet.bgView.frame, actionSheetLocation));
 }
 
 @end


### PR DESCRIPTION
Fixes the bug which would dismiss the picker when it was in `inline` date style.  This was introduced by https://github.com/skywinder/ActionSheetPicker-3.0/pull/528. 